### PR TITLE
Introduce AddressPrefix struct.

### DIFF
--- a/Paymetheus.Bitcoin/BlockChainIdentity.cs
+++ b/Paymetheus.Bitcoin/BlockChainIdentity.cs
@@ -11,48 +11,33 @@ namespace Paymetheus.Bitcoin
         (
             name: "mainnet",
             network: 0xd9b4bef9,
-            coinType: 0,
-            pubKeyHashID: 0x00,
-            scriptHashID: 0x05,
-            wifID: 0x80
+            coinType: 0
         );
 
         public static readonly BlockChainIdentity TestNet3 = new BlockChainIdentity
         (
             name: "testnet3",
             network: 0x0709110b,
-            coinType: 1,
-            pubKeyHashID: 0x6f,
-            scriptHashID: 0xc4,
-            wifID: 0xef
+            coinType: 1
         );
 
         public static readonly BlockChainIdentity SimNet = new BlockChainIdentity
         (
             name: "simnet",
             network: 0x12141c16,
-            coinType: 115,
-            pubKeyHashID: 0x3f,
-            scriptHashID: 0x7b,
-            wifID: 0x64
+            coinType: 115
         );
 
-        private BlockChainIdentity(string name, uint network, uint coinType, byte pubKeyHashID, byte scriptHashID, byte wifID)
+        private BlockChainIdentity(string name, uint network, uint coinType)
         {
             Name = name;
             Network = network;
             Bip44CoinType = coinType;
-            AddressPubKeyHashID = pubKeyHashID;
-            AddressScriptHashID = scriptHashID;
-            WifID = wifID;
         }
 
         public string Name { get; }
         public uint Network { get; }
         public uint Bip44CoinType { get; }
-        public byte AddressPubKeyHashID { get; }
-        public byte AddressScriptHashID { get; }
-        public byte WifID { get; }
 
         public static BlockChainIdentity FromNetworkBits(uint network)
         {
@@ -64,54 +49,6 @@ namespace Paymetheus.Bitcoin
                 return SimNet;
             else
                 throw new UnknownBlockChainException($"Unrecognized or unsupported blockchain described by network ID `{network}`");
-        }
-
-        public static bool IdentityForPubKeyHashID(byte pubKeyHashID, out BlockChainIdentity identity)
-        {
-            if (pubKeyHashID == MainNet.AddressPubKeyHashID)
-            {
-                identity = MainNet;
-                return true;
-            }
-            else if (pubKeyHashID == TestNet3.AddressPubKeyHashID)
-            {
-                identity = TestNet3;
-                return true;
-            }
-            else if (pubKeyHashID == SimNet.AddressPubKeyHashID)
-            {
-                identity = SimNet;
-                return true;
-            }
-            else
-            {
-                identity = null;
-                return false;
-            }
-        }
-
-        public static bool IdentityForScriptHashID(byte scriptHashID, out BlockChainIdentity identity)
-        {
-            if (scriptHashID == MainNet.AddressScriptHashID)
-            {
-                identity = MainNet;
-                return true;
-            }
-            else if (scriptHashID == TestNet3.AddressScriptHashID)
-            {
-                identity = TestNet3;
-                return true;
-            }
-            else if (scriptHashID == SimNet.AddressScriptHashID)
-            {
-                identity = SimNet;
-                return true;
-            }
-            else
-            {
-                identity = null;
-                return false;
-            }
         }
     }
 

--- a/Paymetheus.Bitcoin/Paymetheus.Bitcoin.csproj
+++ b/Paymetheus.Bitcoin/Paymetheus.Bitcoin.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Wallet\Account.cs" />
     <Compile Include="Wallet\AccountProperties.cs" />
     <Compile Include="Wallet\Address.cs" />
+    <Compile Include="Wallet\AddressPrefix.cs" />
     <Compile Include="Wallet\Block.cs" />
     <Compile Include="Wallet\Checksum.cs" />
     <Compile Include="Ripemd160Hash.cs" />

--- a/Paymetheus.Bitcoin/Wallet/Address.cs
+++ b/Paymetheus.Bitcoin/Wallet/Address.cs
@@ -41,7 +41,7 @@ namespace Paymetheus.Bitcoin.Wallet
             public override string Encode()
             {
                 var buffer = new byte[1 + Ripemd160Hash.Length + Checksum.SumLength];
-                buffer[0] = IntendedBlockChain.AddressPubKeyHashID;
+                buffer[0] = AddressPrefix.PayToPubKeyHashPrefix(IntendedBlockChain);
                 Array.Copy(PubKeyHash, 0, buffer, 1, Ripemd160Hash.Length);
                 Checksum.WriteSum(buffer);
                 return Base58.Encode(buffer);
@@ -68,7 +68,7 @@ namespace Paymetheus.Bitcoin.Wallet
             public override string Encode()
             {
                 var buffer = new byte[1 + Ripemd160Hash.Length + Checksum.SumLength];
-                buffer[0] = IntendedBlockChain.AddressScriptHashID;
+                buffer[0] = AddressPrefix.PayToScriptHashPrefix(IntendedBlockChain);
                 Array.Copy(ScriptHash, 0, buffer, 1, Ripemd160Hash.Length);
                 Checksum.WriteSum(buffer);
                 return Base58.Encode(buffer);
@@ -106,14 +106,14 @@ namespace Paymetheus.Bitcoin.Wallet
 
             var addressID = base58DecodedAddress[0];
             BlockChainIdentity intendedBlockChain;
-            if (BlockChainIdentity.IdentityForPubKeyHashID(addressID, out intendedBlockChain))
+            if (AddressPrefix.IdentityForPubkeyHashPrefix(addressID, out intendedBlockChain))
             {
                 var pubKeyHash = new byte[Ripemd160Hash.Length];
                 Array.Copy(base58DecodedAddress, 1, pubKeyHash, 0, Ripemd160Hash.Length);
                 address = new PayToPubKeyHash(intendedBlockChain, pubKeyHash);
                 return true;
             }
-            else if (BlockChainIdentity.IdentityForScriptHashID(addressID, out intendedBlockChain))
+            else if (AddressPrefix.IdentityForScriptHashPrefix(addressID, out intendedBlockChain))
             {
                 var scriptHash = new byte[Ripemd160Hash.Length];
                 Array.Copy(base58DecodedAddress, 1, scriptHash, 0, Ripemd160Hash.Length);

--- a/Paymetheus.Bitcoin/Wallet/AddressPrefix.cs
+++ b/Paymetheus.Bitcoin/Wallet/AddressPrefix.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) 2016 The btcsuite developers
+// Licensed under the ISC license.  See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Paymetheus.Bitcoin.Wallet
+{
+    public struct AddressPrefix
+    {
+        const byte MainNetPayToPubKeyHashPrefix = 0x00;
+        const byte MainNetPayToScriptHashPrefix = 0x05;
+        const byte MainNetWifPrefix = 0x80;
+        const byte TestNet3PayToPubKeyHashPrefix = 0x6f;
+        const byte TestNet3PayToScriptHashPrefix = 0xc4;
+        const byte TestNet3WifPrefix = 0xef;
+        const byte SimNetPayToPubKeyHashPrefix = 0x3f;
+        const byte SimNetPayToScriptHashPrefix = 0x7b;
+        const byte SimNetWifPrefix = 0x64;
+
+        public AddressPrefix(byte prefix)
+        {
+            Prefix = prefix;
+        }
+
+        public byte Prefix { get; }
+
+        public static implicit operator byte(AddressPrefix ap) => ap.Prefix;
+        public static implicit operator AddressPrefix(byte b) => new AddressPrefix(b);
+
+        public static AddressPrefix PayToPubKeyHashPrefix(BlockChainIdentity identity)
+        {
+            if (identity == null)
+                throw new ArgumentNullException(nameof(identity));
+
+            if (identity == BlockChainIdentity.MainNet) return MainNetPayToPubKeyHashPrefix;
+            else if (identity == BlockChainIdentity.TestNet3) return TestNet3PayToPubKeyHashPrefix;
+            else if (identity == BlockChainIdentity.SimNet) return SimNetPayToPubKeyHashPrefix;
+            else throw new UnknownBlockChainException($"Unknown blockchain `{identity.Name}`");
+        }
+
+        public static AddressPrefix PayToScriptHashPrefix(BlockChainIdentity identity)
+        {
+            if (identity == null)
+                throw new ArgumentNullException(nameof(identity));
+
+            if (identity == BlockChainIdentity.MainNet) return MainNetPayToScriptHashPrefix;
+            else if (identity == BlockChainIdentity.TestNet3) return TestNet3PayToScriptHashPrefix;
+            else if (identity == BlockChainIdentity.SimNet) return SimNetPayToScriptHashPrefix;
+            else throw new UnknownBlockChainException($"Unknown blockchain `{identity.Name}`");
+        }
+
+        public static bool IdentityForPubkeyHashPrefix(AddressPrefix prefix, out BlockChainIdentity identity)
+        {
+            if (prefix == MainNetPayToPubKeyHashPrefix)
+            {
+                identity = BlockChainIdentity.MainNet;
+                return true;
+            }
+            else if (prefix == TestNet3PayToPubKeyHashPrefix)
+            {
+                identity = BlockChainIdentity.TestNet3;
+                return true;
+            }
+            else if (prefix == SimNetPayToPubKeyHashPrefix)
+            {
+                identity = BlockChainIdentity.SimNet;
+                return true;
+            }
+            else
+            {
+                identity = null;
+                return false;
+            }
+        }
+
+        public static bool IdentityForScriptHashPrefix(AddressPrefix prefix, out BlockChainIdentity identity)
+        {
+            if (prefix == MainNetPayToScriptHashPrefix)
+            {
+                identity = BlockChainIdentity.MainNet;
+                return true;
+            }
+            else if (prefix == TestNet3PayToScriptHashPrefix)
+            {
+                identity = BlockChainIdentity.TestNet3;
+                return true;
+            }
+            else if (prefix == SimNetPayToScriptHashPrefix)
+            {
+                identity = BlockChainIdentity.SimNet;
+                return true;
+            }
+            else
+            {
+                identity = null;
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This struct is used for defining the kind and the intended network of
an address.  It also provides static conversions methods to and from
various different address kinds and intended blockchains.

This logic is being moved outside of the BlockChainIdentity class to
support more complex address prefixes as well as proving a cleaner
boundary between the Bitcoin protocol code and wallet abstractions.
