### PR TITLE
Rename some rpc commands to something more generic.

### DIFF
--- a/Paymetheus.Rpc/Api.cs
+++ b/Paymetheus.Rpc/Api.cs
@@ -214,8 +214,8 @@ namespace Walletrpc {
             new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.CloseWalletResponse), global::Walletrpc.CloseWalletResponse.Parser, null, null, null, null),
             new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.WalletExistsRequest), global::Walletrpc.WalletExistsRequest.Parser, null, null, null, null),
             new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.WalletExistsResponse), global::Walletrpc.WalletExistsResponse.Parser, new[]{ "Exists" }, null, null, null),
-            new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.StartBtcdRpcRequest), global::Walletrpc.StartBtcdRpcRequest.Parser, new[]{ "NetworkAddress", "Username", "Password", "Certificate" }, null, null, null),
-            new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.StartBtcdRpcResponse), global::Walletrpc.StartBtcdRpcResponse.Parser, null, null, null, null)
+            new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.StartConcensusRpcRequest), global::Walletrpc.StartConcensusRpcRequest.Parser, new[]{ "NetworkAddress", "Username", "Password", "Certificate" }, null, null, null),
+            new pbr::GeneratedCodeInfo(typeof(global::Walletrpc.StartConcensusRpcResponse), global::Walletrpc.StartConcensusRpcResponse.Parser, null, null, null, null)
           }));
     }
     #endregion
@@ -7042,9 +7042,9 @@ namespace Walletrpc {
   }
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-  public sealed partial class StartBtcdRpcRequest : pb::IMessage<StartBtcdRpcRequest> {
-    private static readonly pb::MessageParser<StartBtcdRpcRequest> _parser = new pb::MessageParser<StartBtcdRpcRequest>(() => new StartBtcdRpcRequest());
-    public static pb::MessageParser<StartBtcdRpcRequest> Parser { get { return _parser; } }
+  public sealed partial class StartConcensusRpcRequest : pb::IMessage<StartConcensusRpcRequest> {
+    private static readonly pb::MessageParser<StartConcensusRpcRequest> _parser = new pb::MessageParser<StartConcensusRpcRequest>(() => new StartConcensusRpcRequest());
+    public static pb::MessageParser<StartConcensusRpcRequest> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
       get { return global::Walletrpc.ApiReflection.Descriptor.MessageTypes[47]; }
@@ -7054,21 +7054,21 @@ namespace Walletrpc {
       get { return Descriptor; }
     }
 
-    public StartBtcdRpcRequest() {
+    public StartConcensusRpcRequest() {
       OnConstruction();
     }
 
     partial void OnConstruction();
 
-    public StartBtcdRpcRequest(StartBtcdRpcRequest other) : this() {
+    public StartConcensusRpcRequest(StartConcensusRpcRequest other) : this() {
       networkAddress_ = other.networkAddress_;
       username_ = other.username_;
       password_ = other.password_;
       certificate_ = other.certificate_;
     }
 
-    public StartBtcdRpcRequest Clone() {
-      return new StartBtcdRpcRequest(this);
+    public StartConcensusRpcRequest Clone() {
+      return new StartConcensusRpcRequest(this);
     }
 
     /// <summary>Field number for the "network_address" field.</summary>
@@ -7112,10 +7112,10 @@ namespace Walletrpc {
     }
 
     public override bool Equals(object other) {
-      return Equals(other as StartBtcdRpcRequest);
+      return Equals(other as StartConcensusRpcRequest);
     }
 
-    public bool Equals(StartBtcdRpcRequest other) {
+    public bool Equals(StartConcensusRpcRequest other) {
       if (ReferenceEquals(other, null)) {
         return false;
       }
@@ -7178,7 +7178,7 @@ namespace Walletrpc {
       return size;
     }
 
-    public void MergeFrom(StartBtcdRpcRequest other) {
+    public void MergeFrom(StartConcensusRpcRequest other) {
       if (other == null) {
         return;
       }
@@ -7226,9 +7226,9 @@ namespace Walletrpc {
   }
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-  public sealed partial class StartBtcdRpcResponse : pb::IMessage<StartBtcdRpcResponse> {
-    private static readonly pb::MessageParser<StartBtcdRpcResponse> _parser = new pb::MessageParser<StartBtcdRpcResponse>(() => new StartBtcdRpcResponse());
-    public static pb::MessageParser<StartBtcdRpcResponse> Parser { get { return _parser; } }
+  public sealed partial class StartConcensusRpcResponse : pb::IMessage<StartConcensusRpcResponse> {
+    private static readonly pb::MessageParser<StartConcensusRpcResponse> _parser = new pb::MessageParser<StartConcensusRpcResponse>(() => new StartConcensusRpcResponse());
+    public static pb::MessageParser<StartConcensusRpcResponse> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
       get { return global::Walletrpc.ApiReflection.Descriptor.MessageTypes[48]; }
@@ -7238,24 +7238,24 @@ namespace Walletrpc {
       get { return Descriptor; }
     }
 
-    public StartBtcdRpcResponse() {
+    public StartConcensusRpcResponse() {
       OnConstruction();
     }
 
     partial void OnConstruction();
 
-    public StartBtcdRpcResponse(StartBtcdRpcResponse other) : this() {
+    public StartConcensusRpcResponse(StartConcensusRpcResponse other) : this() {
     }
 
-    public StartBtcdRpcResponse Clone() {
-      return new StartBtcdRpcResponse(this);
+    public StartConcensusRpcResponse Clone() {
+      return new StartConcensusRpcResponse(this);
     }
 
     public override bool Equals(object other) {
-      return Equals(other as StartBtcdRpcResponse);
+      return Equals(other as StartConcensusRpcResponse);
     }
 
-    public bool Equals(StartBtcdRpcResponse other) {
+    public bool Equals(StartConcensusRpcResponse other) {
       if (ReferenceEquals(other, null)) {
         return false;
       }
@@ -7282,7 +7282,7 @@ namespace Walletrpc {
       return size;
     }
 
-    public void MergeFrom(StartBtcdRpcResponse other) {
+    public void MergeFrom(StartConcensusRpcResponse other) {
       if (other == null) {
         return;
       }

--- a/Paymetheus.Rpc/ApiGrpc.cs
+++ b/Paymetheus.Rpc/ApiGrpc.cs
@@ -698,8 +698,8 @@ namespace Walletrpc {
     static readonly Marshaller<global::Walletrpc.OpenWalletResponse> __Marshaller_OpenWalletResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.OpenWalletResponse.Parser.ParseFrom);
     static readonly Marshaller<global::Walletrpc.CloseWalletRequest> __Marshaller_CloseWalletRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.CloseWalletRequest.Parser.ParseFrom);
     static readonly Marshaller<global::Walletrpc.CloseWalletResponse> __Marshaller_CloseWalletResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.CloseWalletResponse.Parser.ParseFrom);
-    static readonly Marshaller<global::Walletrpc.StartBtcdRpcRequest> __Marshaller_StartBtcdRpcRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.StartBtcdRpcRequest.Parser.ParseFrom);
-    static readonly Marshaller<global::Walletrpc.StartBtcdRpcResponse> __Marshaller_StartBtcdRpcResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.StartBtcdRpcResponse.Parser.ParseFrom);
+    static readonly Marshaller<global::Walletrpc.StartConcensusRpcRequest> __Marshaller_StartConcensusRpcRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.StartConcensusRpcRequest.Parser.ParseFrom);
+    static readonly Marshaller<global::Walletrpc.StartConcensusRpcResponse> __Marshaller_StartConcensusRpcResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Walletrpc.StartConcensusRpcResponse.Parser.ParseFrom);
 
     static readonly Method<global::Walletrpc.WalletExistsRequest, global::Walletrpc.WalletExistsResponse> __Method_WalletExists = new Method<global::Walletrpc.WalletExistsRequest, global::Walletrpc.WalletExistsResponse>(
         MethodType.Unary,
@@ -729,12 +729,12 @@ namespace Walletrpc {
         __Marshaller_CloseWalletRequest,
         __Marshaller_CloseWalletResponse);
 
-    static readonly Method<global::Walletrpc.StartBtcdRpcRequest, global::Walletrpc.StartBtcdRpcResponse> __Method_StartBtcdRpc = new Method<global::Walletrpc.StartBtcdRpcRequest, global::Walletrpc.StartBtcdRpcResponse>(
+    static readonly Method<global::Walletrpc.StartConcensusRpcRequest, global::Walletrpc.StartConcensusRpcResponse> __Method_StartConcensusRpc = new Method<global::Walletrpc.StartConcensusRpcRequest, global::Walletrpc.StartConcensusRpcResponse>(
         MethodType.Unary,
         __ServiceName,
-        "StartBtcdRpc",
-        __Marshaller_StartBtcdRpcRequest,
-        __Marshaller_StartBtcdRpcResponse);
+        "StartConcensusRpc",
+        __Marshaller_StartConcensusRpcRequest,
+        __Marshaller_StartConcensusRpcResponse);
 
     // service descriptor
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
@@ -761,10 +761,10 @@ namespace Walletrpc {
       global::Walletrpc.CloseWalletResponse CloseWallet(global::Walletrpc.CloseWalletRequest request, CallOptions options);
       AsyncUnaryCall<global::Walletrpc.CloseWalletResponse> CloseWalletAsync(global::Walletrpc.CloseWalletRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
       AsyncUnaryCall<global::Walletrpc.CloseWalletResponse> CloseWalletAsync(global::Walletrpc.CloseWalletRequest request, CallOptions options);
-      global::Walletrpc.StartBtcdRpcResponse StartBtcdRpc(global::Walletrpc.StartBtcdRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      global::Walletrpc.StartBtcdRpcResponse StartBtcdRpc(global::Walletrpc.StartBtcdRpcRequest request, CallOptions options);
-      AsyncUnaryCall<global::Walletrpc.StartBtcdRpcResponse> StartBtcdRpcAsync(global::Walletrpc.StartBtcdRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      AsyncUnaryCall<global::Walletrpc.StartBtcdRpcResponse> StartBtcdRpcAsync(global::Walletrpc.StartBtcdRpcRequest request, CallOptions options);
+      global::Walletrpc.StartConcensusRpcResponse StartConcensusRpc(global::Walletrpc.StartConcensusRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      global::Walletrpc.StartConcensusRpcResponse StartConcensusRpc(global::Walletrpc.StartConcensusRpcRequest request, CallOptions options);
+      AsyncUnaryCall<global::Walletrpc.StartConcensusRpcResponse> StartConcensusRpcAsync(global::Walletrpc.StartConcensusRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      AsyncUnaryCall<global::Walletrpc.StartConcensusRpcResponse> StartConcensusRpcAsync(global::Walletrpc.StartConcensusRpcRequest request, CallOptions options);
     }
 
     // server-side interface
@@ -774,7 +774,7 @@ namespace Walletrpc {
       Task<global::Walletrpc.CreateWalletResponse> CreateWallet(global::Walletrpc.CreateWalletRequest request, ServerCallContext context);
       Task<global::Walletrpc.OpenWalletResponse> OpenWallet(global::Walletrpc.OpenWalletRequest request, ServerCallContext context);
       Task<global::Walletrpc.CloseWalletResponse> CloseWallet(global::Walletrpc.CloseWalletRequest request, ServerCallContext context);
-      Task<global::Walletrpc.StartBtcdRpcResponse> StartBtcdRpc(global::Walletrpc.StartBtcdRpcRequest request, ServerCallContext context);
+      Task<global::Walletrpc.StartConcensusRpcResponse> StartConcensusRpc(global::Walletrpc.StartConcensusRpcRequest request, ServerCallContext context);
     }
 
     // client stub
@@ -863,24 +863,24 @@ namespace Walletrpc {
         var call = CreateCall(__Method_CloseWallet, options);
         return Calls.AsyncUnaryCall(call, request);
       }
-      public global::Walletrpc.StartBtcdRpcResponse StartBtcdRpc(global::Walletrpc.StartBtcdRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public global::Walletrpc.StartConcensusRpcResponse StartConcensusRpc(global::Walletrpc.StartConcensusRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
-        var call = CreateCall(__Method_StartBtcdRpc, new CallOptions(headers, deadline, cancellationToken));
+        var call = CreateCall(__Method_StartConcensusRpc, new CallOptions(headers, deadline, cancellationToken));
         return Calls.BlockingUnaryCall(call, request);
       }
-      public global::Walletrpc.StartBtcdRpcResponse StartBtcdRpc(global::Walletrpc.StartBtcdRpcRequest request, CallOptions options)
+      public global::Walletrpc.StartConcensusRpcResponse StartConcensusRpc(global::Walletrpc.StartConcensusRpcRequest request, CallOptions options)
       {
-        var call = CreateCall(__Method_StartBtcdRpc, options);
+        var call = CreateCall(__Method_StartConcensusRpc, options);
         return Calls.BlockingUnaryCall(call, request);
       }
-      public AsyncUnaryCall<global::Walletrpc.StartBtcdRpcResponse> StartBtcdRpcAsync(global::Walletrpc.StartBtcdRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public AsyncUnaryCall<global::Walletrpc.StartConcensusRpcResponse> StartConcensusRpcAsync(global::Walletrpc.StartConcensusRpcRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
-        var call = CreateCall(__Method_StartBtcdRpc, new CallOptions(headers, deadline, cancellationToken));
+        var call = CreateCall(__Method_StartConcensusRpc, new CallOptions(headers, deadline, cancellationToken));
         return Calls.AsyncUnaryCall(call, request);
       }
-      public AsyncUnaryCall<global::Walletrpc.StartBtcdRpcResponse> StartBtcdRpcAsync(global::Walletrpc.StartBtcdRpcRequest request, CallOptions options)
+      public AsyncUnaryCall<global::Walletrpc.StartConcensusRpcResponse> StartConcensusRpcAsync(global::Walletrpc.StartConcensusRpcRequest request, CallOptions options)
       {
-        var call = CreateCall(__Method_StartBtcdRpc, options);
+        var call = CreateCall(__Method_StartConcensusRpc, options);
         return Calls.AsyncUnaryCall(call, request);
       }
     }
@@ -893,7 +893,7 @@ namespace Walletrpc {
           .AddMethod(__Method_CreateWallet, serviceImpl.CreateWallet)
           .AddMethod(__Method_OpenWallet, serviceImpl.OpenWallet)
           .AddMethod(__Method_CloseWallet, serviceImpl.CloseWallet)
-          .AddMethod(__Method_StartBtcdRpc, serviceImpl.StartBtcdRpc).Build();
+          .AddMethod(__Method_StartConcensusRpc, serviceImpl.StartConcensusRpc).Build();
     }
 
     // creates a new client

--- a/Paymetheus.Rpc/WalletClient.cs
+++ b/Paymetheus.Rpc/WalletClient.cs
@@ -86,18 +86,18 @@ namespace Paymetheus.Rpc
             return resp.Exists;
         }
 
-        public async Task StartBtcdRpc(ConsensusServerRpcOptions options)
+        public async Task StartConcensusRpc(ConsensusServerRpcOptions options)
         {
             var certificateTask = ReadFileAsync(options.CertificatePath);
             var client = WalletLoaderService.NewClient(_channel);
-            var request = new StartBtcdRpcRequest
+            var request = new StartConcensusRpcRequest
             {
                 NetworkAddress = options.NetworkAddress,
                 Username = options.RpcUser,
                 Password = ByteString.CopyFromUtf8(options.RpcPassword),
                 Certificate = ByteString.CopyFrom(await certificateTask),
             };
-            await client.StartBtcdRpcAsync(request, cancellationToken: _tokenSource.Token);
+            await client.StartConcensusRpcAsync(request, cancellationToken: _tokenSource.Token);
         }
 
         private async Task<byte[]> ReadFileAsync(string filePath)

--- a/Paymetheus.Rpc/WalletClient.cs
+++ b/Paymetheus.Rpc/WalletClient.cs
@@ -20,7 +20,7 @@ namespace Paymetheus.Rpc
 {
     public sealed class WalletClient : IDisposable
     {
-        private static readonly SemanticVersion RequiredRpcServerVersion = new SemanticVersion(0, 3, 0);
+        private static readonly SemanticVersion RequiredRpcServerVersion = new SemanticVersion(1, 0, 0);
 
         public static void Initialize()
         {

--- a/Paymetheus.Rpc/protos/api.proto
+++ b/Paymetheus.Rpc/protos/api.proto
@@ -46,7 +46,7 @@ service WalletLoaderService {
 	rpc CreateWallet (CreateWalletRequest) returns (CreateWalletResponse);
 	rpc OpenWallet (OpenWalletRequest) returns (OpenWalletResponse);
 	rpc CloseWallet (CloseWalletRequest) returns (CloseWalletResponse);
-	rpc StartBtcdRpc (StartBtcdRpcRequest) returns (StartBtcdRpcResponse);
+	rpc StartConcensusRpc (StartConcensusRpcRequest) returns (StartConcensusRpcResponse);
 }
 
 message TransactionDetails {
@@ -313,10 +313,10 @@ message WalletExistsResponse {
 	bool exists = 1;
 }
 
-message StartBtcdRpcRequest {
+message StartConcensusRpcRequest {
 	string network_address = 1;
 	string username = 2;
 	bytes password = 3;
 	bytes certificate = 4;
 }
-message StartBtcdRpcResponse {}
+message StartConcensusRpcResponse {}

--- a/Paymetheus/StartupWizard.cs
+++ b/Paymetheus/StartupWizard.cs
@@ -93,7 +93,7 @@ namespace Paymetheus
                     ConsensusServerRpcUsername, ConsensusServerRpcPassword, ConsensusServerCertificateFile);
                 try
                 {
-                    await App.Current.WalletRpcClient.StartBtcdRpc(rpcOptions);
+                    await App.Current.WalletRpcClient.StartConcensusRpc(rpcOptions);
                 }
                 catch (Exception ex) when (ErrorHandling.IsTransient(ex) || ErrorHandling.IsClientError(ex))
                 {


### PR DESCRIPTION
StartBtcdRpc becomes StartConcensusRpc.

This is useful for forks such as decred or if someone were to write
another compatible server.

This requires btcsuite/btcwallet#381
