### PR TITLE
Use Paymetheus' local AppData directory for wallet.

### DIFF
--- a/Paymetheus.Rpc/ConsensusServerRpcOptions.cs
+++ b/Paymetheus.Rpc/ConsensusServerRpcOptions.cs
@@ -24,6 +24,6 @@ namespace Paymetheus.Rpc
         public string CertificatePath { get; }
 
         public static string LocalCertificateFilePath() =>
-            Path.Combine(Portability.LocalAppData(Environment.OSVersion.Platform, ApplicationName), "rpc.cert");
+            Path.Combine(Portability.LocalAppData(Environment.OSVersion.Platform, "", ApplicationName), "rpc.cert");
     }
 }

--- a/Paymetheus.Rpc/Portability.cs
+++ b/Paymetheus.Rpc/Portability.cs
@@ -6,26 +6,35 @@ using System.IO;
 
 namespace Paymetheus.Rpc
 {
-    static class Portability
+    public static class Portability
     {
-        public static string LocalAppData(PlatformID platform, string processName)
+        public static string LocalAppData(PlatformID platform, string organization, string product)
         {
-            if (processName == null)
-                throw new ArgumentNullException(nameof(processName));
-            if (processName.Length == 0)
-                throw new ArgumentException(nameof(processName) + " may not have zero length");
+            if (organization == null)
+                throw new ArgumentNullException(nameof(organization));
+            if (product == null)
+                throw new ArgumentNullException(nameof(product));
+            if (product.Length == 0)
+                throw new ArgumentException(nameof(product) + " may not have zero length");
 
             switch (platform)
             {
                 case PlatformID.Win32NT:
                     return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        ToUpper(processName));
+                        ToUpper(organization), ToUpper(product));
                 case PlatformID.MacOSX:
                     return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                        "Library", "Application Support", ToUpper(processName));
+                        "Library", "Application Support", ToUpper(organization), ToUpper(product));
                 case PlatformID.Unix:
-                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                        ToDotLower(processName));
+                    var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                    if (organization == "")
+                    {
+                        return Path.Combine(homeDirectory, ToDotLower(product));
+                    }
+                    else
+                    {
+                        return Path.Combine(homeDirectory, ToDotLower(organization), product.ToLower());
+                    }
                 default:
                     throw new PlatformNotSupportedException($"PlatformID={platform}");
             }
@@ -33,8 +42,11 @@ namespace Paymetheus.Rpc
 
         private static string ToUpper(string value)
         {
+            if (value == "")
+                return "";
+
             var firstChar = value[0];
-            if (char.IsUpper(firstChar))
+            if (char.IsUpper(firstChar) || !char.IsLetter(firstChar))
                 return value;
             else
                 return char.ToUpper(firstChar) + value.Substring(1);
@@ -42,8 +54,10 @@ namespace Paymetheus.Rpc
 
         private static string ToDotLower(string value)
         {
-            var firstChar = value[0];
-            return "." + char.ToLower(firstChar) + value.Substring(1);
+            if (value == "")
+                return "";
+
+            return "." + value.ToLower();
         }
     }
 }

--- a/Paymetheus.Rpc/TransportSecurity.cs
+++ b/Paymetheus.Rpc/TransportSecurity.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2016 The btcsuite developers
 // Licensed under the ISC license.  See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,21 +12,21 @@ namespace Paymetheus.Rpc
     {
         private const string CertificateFile = "rpc.cert";
 
-        private static string CertificatePath() =>
-            Path.Combine(WalletProcess.ApplicationDataDirectory, CertificateFile);
-
         // Need a non-void type to use for the TaskCompletionSource below.  Name is
         // borrowed from functional programming.
         private struct Unit { }
 
-        public static async Task<string> ReadModifiedCertificateAsync()
+        public static async Task<string> ReadModifiedCertificateAsync(string directory)
         {
+            if (directory == null)
+                throw new ArgumentNullException(nameof(directory));
+
             // Asynchronously wait until the certificate file has been written by the wallet
             // process before reading.
             var tcs = new TaskCompletionSource<Unit>();
             var fsw = new FileSystemWatcher
             {
-                Path = WalletProcess.ApplicationDataDirectory,
+                Path = directory,
                 EnableRaisingEvents = true,
             };
             using (fsw)
@@ -40,7 +41,7 @@ namespace Paymetheus.Rpc
                 await tcs.Task;
             }
 
-            var certificatePath = CertificatePath();
+            var certificatePath = Path.Combine(directory, CertificateFile);
 
             // On Windows, process file locks may prevent reading the file even after the
             // filesystem notification was received.  Polling for the unlocked file is icky

--- a/Paymetheus.Rpc/WalletProcess.cs
+++ b/Paymetheus.Rpc/WalletProcess.cs
@@ -9,13 +9,12 @@ namespace Paymetheus.Rpc
 {
     public static class WalletProcess
     {
-        public static readonly string ApplicationDataDirectory =
-            Portability.LocalAppData(Environment.OSVersion.Platform, "Btcwallet");
-
-        public static Process Start(BlockChainIdentity intendedNetwork)
+        public static Process Start(BlockChainIdentity intendedNetwork, string appDataDirectory)
         {
             if (intendedNetwork == null)
                 throw new ArgumentNullException(nameof(intendedNetwork));
+            if (appDataDirectory == null)
+                throw new ArgumentNullException(nameof(appDataDirectory));
 
             var networkFlag = "";
             if (intendedNetwork == BlockChainIdentity.TestNet3)
@@ -33,7 +32,7 @@ namespace Paymetheus.Rpc
 
             var processInfo = new ProcessStartInfo();
             processInfo.FileName = "btcwallet";
-            processInfo.Arguments = $"{networkFlag} --noinitialload --experimentalrpclisten={v4ListenAddress} --onetimetlskey";
+            processInfo.Arguments = $"{networkFlag} --noinitialload --experimentalrpclisten={v4ListenAddress} --onetimetlskey --datadir=\"{appDataDirectory}\"";
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardError = true;
             processInfo.RedirectStandardOutput = true;

--- a/Paymetheus/App.xaml.cs
+++ b/Paymetheus/App.xaml.cs
@@ -5,6 +5,7 @@ using Paymetheus.Bitcoin;
 using Paymetheus.Rpc;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -62,13 +63,18 @@ namespace Paymetheus
                 // TODO: Make network selectable (parse e.Args for a network)
                 var activeNetwork = BlockChainIdentity.TestNet3;
 
+                var appDataDir = Portability.LocalAppData(Environment.OSVersion.Platform,
+                    AssemblyResources.Organization, AssemblyResources.ProductName);
+
+                Directory.CreateDirectory(appDataDir);
+
                 // Begin the asynchronous reading of the certificate before starting the wallet
                 // process.  This uses filesystem events to know when to begin reading the certificate,
                 // and if there is too much delay between wallet writing the cert and this process
                 // beginning to observe the change, the event may never fire and the cert won't be read.
-                var rootCertificateTask = TransportSecurity.ReadModifiedCertificateAsync();
+                var rootCertificateTask = TransportSecurity.ReadModifiedCertificateAsync(appDataDir);
 
-                var walletProcess = WalletProcess.Start(activeNetwork);
+                var walletProcess = WalletProcess.Start(activeNetwork, appDataDir);
 
                 WalletClient walletClient;
                 try

--- a/Paymetheus/AssemblyResources.cs
+++ b/Paymetheus/AssemblyResources.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2016 The btcsuite developers
+// Licensed under the ISC license.  See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Reflection;
+
+namespace Paymetheus
+{
+    static class AssemblyResources
+    {
+        public static string ProductName { get; }
+        public static string Organization { get; }
+
+        static AssemblyResources()
+        {
+            var asm = Assembly.GetEntryAssembly();
+            var metadata = asm?.GetCustomAttributes<AssemblyMetadataAttribute>();
+
+            AssemblyProductAttribute productAttribute = null;
+            try
+            {
+                productAttribute = asm?.GetCustomAttribute<AssemblyProductAttribute>();
+            }
+            finally
+            {
+                ProductName = productAttribute?.Product ?? "Paymetheus";
+            }
+
+            AssemblyMetadataAttribute organizationAttribute = null;
+            try
+            {
+                organizationAttribute = metadata?.FirstOrDefault(a => a.Key == "Organization");
+            }
+            finally
+            {
+                Organization = organizationAttribute?.Value ?? "";
+            }
+        }
+    }
+}

--- a/Paymetheus/Paymetheus.csproj
+++ b/Paymetheus/Paymetheus.csproj
@@ -161,6 +161,7 @@
     <Compile Include="CreateOrImportSeedView.xaml.cs">
       <DependentUpon>CreateOrImportSeedView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="AssemblyResources.cs" />
     <Compile Include="StartupWizard.cs" />
     <Compile Include="ConnectionWizardView.xaml.cs">
       <DependentUpon>ConnectionWizardView.xaml</DependentUpon>

--- a/Paymetheus/Properties/AssemblyInfo.cs
+++ b/Paymetheus/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: AssemblyMetadata("Organization", "Btcsuite")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Add AssemblyResources static class for reading attributes from the
entry assembly.  This is used to access the name of the application
which is used for the local appdata directory.

Fixes #52.
