### PR TITLE
Look up application title from resources.

### DIFF
--- a/Paymetheus/AssemblyResources.cs
+++ b/Paymetheus/AssemblyResources.cs
@@ -8,6 +8,7 @@ namespace Paymetheus
 {
     static class AssemblyResources
     {
+        public static string Title { get; }
         public static string ProductName { get; }
         public static string Organization { get; }
 
@@ -15,6 +16,16 @@ namespace Paymetheus
         {
             var asm = Assembly.GetEntryAssembly();
             var metadata = asm?.GetCustomAttributes<AssemblyMetadataAttribute>();
+
+            AssemblyTitleAttribute titleAttribute = null;
+            try
+            {
+                titleAttribute = asm?.GetCustomAttribute<AssemblyTitleAttribute>();
+            }
+            finally
+            {
+                Title = titleAttribute?.Title ?? "Paymetheus";
+            }
 
             AssemblyProductAttribute productAttribute = null;
             try

--- a/Paymetheus/MainWindow.xaml
+++ b/Paymetheus/MainWindow.xaml
@@ -5,7 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Paymetheus"
         mc:Ignorable="d"
-        Title="Paymetheus" Height="600" Width="1050" Closed="Window_Closed">
+        Title="{Binding Path=WindowTitle, Mode=OneTime}"
+        Height="600" Width="1050"
+        Closed="Window_Closed">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}">
             <Setter Property="Margin" Value="0,0,0,4" />

--- a/Paymetheus/MainWindow.xaml.cs
+++ b/Paymetheus/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2016 The btcsuite developers
 // Licensed under the ISC license.  See LICENSE file in the project root for full license information.
 
+using Paymetheus.Bitcoin;
 using System.Windows;
 using System.Windows.Controls;
 

--- a/Paymetheus/Properties/AssemblyInfo.cs
+++ b/Paymetheus/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Windows;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Paymetheus")]
+[assembly: AssemblyTitle("Paymetheus Bitcoin Wallet")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]

--- a/Paymetheus/ShellViewModel.cs
+++ b/Paymetheus/ShellViewModel.cs
@@ -16,6 +16,19 @@ namespace Paymetheus
     {
         public ShellViewModel()
         {
+            // Set the window title to the title in the resources assembly.
+            // Append network name to window title if not running on mainnet.
+            var activeNetwork = App.Current.ActiveNetwork;
+            var productTitle = AssemblyResources.Title;
+            if (activeNetwork == BlockChainIdentity.MainNet)
+            {
+                WindowTitle = productTitle;
+            }
+            else
+            {
+                WindowTitle = $"{productTitle} [{activeNetwork.Name}]";
+            }
+
             CreateAccountCommand = new DelegateCommand(CreateAccount);
             NavigateBack = new DelegateCommand(ShowRecentActivity);
 
@@ -30,6 +43,8 @@ namespace Paymetheus
         private Wallet _wallet;
         private readonly RecentActivityViewModel _recentActivityViewModel;
         private AccountViewModel _accountViewModel;
+
+        public string WindowTitle { get; }
 
         private ViewModelBase _visibleContent;
         public ViewModelBase VisibleContent
@@ -100,14 +115,6 @@ namespace Paymetheus
 
         private void OnSyncedWallet()
         {
-            // Append network name to window title if not running on mainnet.
-            // TODO: Query product name from resources assembly.
-            const string ProductName = "Paymetheus";
-            if (_wallet.ActiveChain == BlockChainIdentity.MainNet)
-                Application.Current.MainWindow.Title = ProductName;
-            else
-                Application.Current.MainWindow.Title = $"{ProductName} [{_wallet.ActiveChain.Name}]";
-
             var txSet = _wallet.RecentTransactions;
             var recentTx = txSet.UnminedTransactions
                 .Select(x => new TransactionViewModel(_wallet, x.Value, BlockIdentity.Unmined))


### PR DESCRIPTION
Set the full window title earlier in the application lifetime, instead
of appending an alternate network name for non-mainnet wallets after the
wallet has been opened and synchronization completed.

Rename the title from just "Paymetheus" to "Paymetheus Bitcoin
Wallet".  This will allow forks for other currencies to rename the
title so multiple Paymetheus instances can be run without confusion
about which currency each is for.  This affects both the window title
and the process name in the Windows task manager.
